### PR TITLE
adding `proclaim.includes` and `proclaim.doesNotInclude`

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -16,6 +16,42 @@
         return (Object.prototype.toString.call(val) === '[object Arguments]');
     }
 
+    // Utility for checking whether a value is plain object
+    function isPlainObject(val) {
+        return Object.prototype.toString.call(val) === '[object Object]';
+    }
+
+    // Utility for checking whether an object contains another object
+    function includes(haystack, needle) {
+        /*jshint maxdepth: 3*/
+        var i;
+
+        // Array#indexOf, but ie...
+        if (isArray(haystack)) {
+            for (i = haystack.length - 1; i >= 0; i = i - 1) {
+                if (haystack[i] === needle) {
+                    return true;
+                }
+            }
+        }
+
+        // String#indexOf
+        if (typeof haystack === 'string') {
+            if (haystack.indexOf(needle) !== -1) {
+                return true;
+            }
+        }
+
+        // Object#hasOwnProperty
+        if (isPlainObject(haystack)) {
+            if (haystack.hasOwnProperty(needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // Utility for checking whether a value is an array
     var isArray = Array.isArray || function (val) {
         return (Object.prototype.toString.call(val) === '[object Array]');
@@ -383,6 +419,19 @@
         }
     };
 
+    // Assert that an object includes something
+    proclaim.includes = function (haystack, needle, msg) {
+        if (!includes(haystack, needle)) {
+            fail(haystack, needle, msg, 'include');
+        }
+    };
+
+    // Assert that an object does not include something
+    proclaim.doesNotInclude = function (haystack, needle, msg) {
+        if (includes(haystack, needle)) {
+            fail(haystack, needle, msg, '!include');
+        }
+    };
 
     // Exports
     // -------

--- a/test/unit/proclaim.js
+++ b/test/unit/proclaim.js
@@ -801,6 +801,104 @@
 
         });
 
+        describe('includes()', function () {
+            it('should be a function', function () {
+                assert.strictEqual(typeof proclaim.includes, 'function');
+            });
+
+            describe('given an array', function () {
+                it('should throw if "needle" is not found', function () {
+                    assert.throws(function () {
+                        proclaim.includes([ 1, 2, 3 ], 4);
+                    }, proclaim.AssertionError);
+                });
+
+                it('should not throw if "needle" is found', function () {
+                    assert.doesNotThrow(function () {
+                        proclaim.includes([ 1, 2, 3, 4 ], 4);
+                    });
+                });
+            });
+
+            describe('given a string', function () {
+                it('should throw if "needle" is not found', function () {
+                    assert.throws(function () {
+                        proclaim.includes('hello', 'world');
+                    }, proclaim.AssertionError);
+                });
+
+                it('should not throw if "needle" is found', function () {
+                    assert.doesNotThrow(function () {
+                        proclaim.includes('hello world', 'world');
+                    });
+                });
+            });
+
+            describe('given an object', function () {
+                it('should throw if the "needle" property is not found', function () {
+                    assert.throws(function () {
+                        proclaim.includes({ hello: true }, 'world');
+                    }, proclaim.AssertionError);
+                });
+
+                it('should not throw if the "needle" property is found', function () {
+                    assert.doesNotThrow(function () {
+                        proclaim.includes({ hello: true, world: false }, 'world');
+                    });
+                });
+
+            });
+        });
+
+        describe('doesNotInclude()', function () {
+            it('should be a function', function () {
+                assert.strictEqual(typeof proclaim.doesNotInclude, 'function');
+            });
+
+            describe('given an array', function () {
+                it('should throw if "needle" is not found', function () {
+                    assert.doesNotThrow(function () {
+                        proclaim.doesNotInclude([ 1, 2, 3 ], 4);
+                    });
+                });
+
+                it('should not throw if "needle" is found', function () {
+                    assert.throws(function () {
+                        proclaim.doesNotInclude([ 1, 2, 3, 4 ], 4);
+                    }, proclaim.AssertionError);
+                });
+            });
+
+            describe('given a string', function () {
+                it('should throw if "needle" is not found', function () {
+                    assert.doesNotThrow(function () {
+                        proclaim.doesNotInclude('hello', 'world');
+                    });
+                });
+
+                it('should not throw if "needle" is found', function () {
+                    assert.throws(function () {
+                        proclaim.doesNotInclude('hello world', 'world');
+                    }, proclaim.AssertionError);
+                });
+            });
+
+            describe('given an object', function () {
+                it('should throw if the "needle" property is not found', function () {
+                    assert.doesNotThrow(function () {
+                        proclaim.doesNotInclude({ hello: true }, 'world');
+                    });
+                });
+
+                it('should not throw if the "needle" property is found', function () {
+                    assert.throws(function () {
+                        proclaim.doesNotInclude({ hello: true, world: false }, 'world');
+                    }, proclaim.AssertionError);
+                });
+
+            });
+        });
+
     });
 
 } ());


### PR DESCRIPTION
Added assertion methods for inclusion.

Works on:
- arrays (`Array#indexOf` shim)
- strings (`String#indexOf`)
- ("plain") objects (`Object#hasOwnProperty`)
