### PR TITLE
thrown exceptions should be useful and easy to debug

### DIFF
--- a/test/unit/proclaim.js
+++ b/test/unit/proclaim.js
@@ -943,4 +943,12 @@
 
     });
 
+    it('should throw descriptive errors', function () {
+        try {
+            proclaim.equal(1, 2);
+        } catch (err) {
+            proclaim.isNotNull(err.message);
+        }
+    });
+
 } ());


### PR DESCRIPTION
the currently thrown exceptions are horribly difficult to debug.  i've only added a failing test as i'm short on time atm.  within a few days, i should be able to fix this.

current output from `make test`:

``` sh
  ✖ 1 of 133 tests failed:

  1)  should throw descriptive errors:

  AssertionError: undefined undefined undefined
      at /Users/stephenmathieson/work/proclaim/lib/proclaim.js:186:32
      at Object.<anonymous> (/Users/stephenmathieson/work/proclaim/lib/proclaim.js:466:3)
      at Module._compile (module.js:456:26)
      at Object.Module._extensions..js (module.js:474:10)
      at Module.load (module.js:356:32)
      at Function.Module._load (module.js:312:12)
      at Module.require (module.js:364:17)
      at require (module.js:380:17)
      at /Users/stephenmathieson/work/proclaim/test/unit/proclaim.js:10:20
      at Object.<anonymous> (/Users/stephenmathieson/work/proclaim/test/unit/proclaim.js:954:3)
      at Module._compile (module.js:456:26)
      at Object.Module._extensions..js (module.js:474:10)
      at Module.load (module.js:356:32)
      at Function.Module._load (module.js:312:12)
      at Module.require (module.js:364:17)
      at require (module.js:380:17)
      at /Users/stephenmathieson/work/proclaim/node_modules/mocha/lib/mocha.js:152:27
      at Array.forEach (native)
      at Mocha.loadFiles (/Users/stephenmathieson/work/proclaim/node_modules/mocha/lib/mocha.js:149:14)
      at Mocha.run (/Users/stephenmathieson/work/proclaim/node_modules/mocha/lib/mocha.js:305:31)
      at Object.<anonymous> (/Users/stephenmathieson/work/proclaim/node_modules/mocha/bin/_mocha:327:7)
      at Module._compile (module.js:456:26)
      at Object.Module._extensions..js (module.js:474:10)
      at Module.load (module.js:356:32)
      at Function.Module._load (module.js:312:12)
      at Function.Module.runMain (module.js:497:10)
      at startup (node.js:119:16)
      at node.js:903:3


make: *** [test-unit] Error 1
```
