### PR TITLE
removing './' from component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -11,8 +11,8 @@
     "homepage": "https://github.com/rowanmanning/proclaim",
     "bugs": "https://github.com/rowanmanning/proclaim/issues",
 
-    "main": "./lib/proclaim.js",
+    "main": "lib/proclaim.js",
     "scripts": [
-        "./lib/proclaim.js"
+        "lib/proclaim.js"
     ]
 }


### PR DESCRIPTION
this is a problem with `component-build`, but figured it'd be easier to fix here...

when using `proclaim` as a dep of a component, we'll get this exception:

```
Uncaught Error: Failed to alias "rowanmanning-proclaim/lib/proclaim.js", it does not exist 
```

as the actual path to `proclaim` is `rowanmanning-proclaim/./lib/proclaim.js`.
