### PR TITLE
regular expression deep comparison 

### DIFF
--- a/test/unit/proclaim.js
+++ b/test/unit/proclaim.js
@@ -196,16 +196,25 @@
             });
 
             it('should handle RegExps', function () {
-                assert.throws(function () {
-                    var a = new RegExp('goodbye', 'g'),
-                        b = /goodbye/gi,
-                        c = new RegExp('hello', 'g'),
-                        d = /hello/i;
+                var a = new RegExp('goodbye', 'g'),
+                    b = /goodbye/gi,
+                    c = new RegExp('hello', 'g'),
+                    d = /hello/i,
+                    e = new RegExp('hello', 'i');
 
+                assert.doesNotThrow(function () {
                     proclaim.deepEqual(a, a);
+                });
+
+                assert.throws(function () {
                     proclaim.deepEqual(a, b);
                     proclaim.deepEqual(a, c);
                     proclaim.deepEqual(a, d);
+                    proclaim.deepEqual(a, e);
+                });
+
+                assert.doesNotThrow(function () {
+                    proclaim.deepEqual(d, e);
                 });
             });
         });


### PR DESCRIPTION
proclaim does not currently handle deepEqual checks on regular expressions (see commit)
