### PR TITLE
Rename includes => include

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Assert that `actual` matches the RegExp in `expected`.
 Assert that `actual` does not match the RegExp in `expected`.
 
 
-### proclaim.includes( haystack, needle, [message] )
+### proclaim.include( haystack, needle, [message] )
 
 Assert that `haystack` contains `needle`. For strings and arrays, this asserts that `indexOf` returns a value other than `-1`. For objects, this method asserts that `needle` is the name of a property on `haystack`.
 

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -219,7 +219,7 @@
     };
 
     // Assert that an object includes something
-    proclaim.includes = function (haystack, needle, msg) {
+    proclaim.include = function (haystack, needle, msg) {
         if (!includes(haystack, needle)) {
             fail(haystack, needle, msg, 'include');
         }

--- a/test/unit/proclaim.js
+++ b/test/unit/proclaim.js
@@ -786,20 +786,20 @@
 
         });
 
-        describe('includes()', function () {
+        describe('include()', function () {
 
             it('should be a function', function () {
-                assert.isFunction(proclaim.includes);
+                assert.isFunction(proclaim.include);
             });
 
             describe('given an array', function () {
 
                 it('should throw if "needle" is not found', function () {
-                    assert.throws(callFn(proclaim.includes, [ 1, 2, 3 ], 4), proclaim.AssertionError);
+                    assert.throws(callFn(proclaim.include, [ 1, 2, 3 ], 4), proclaim.AssertionError);
                 });
 
                 it('should not throw if "needle" is found', function () {
-                    assert.doesNotThrow(callFn(proclaim.includes, [ 1, 2, 3, 4 ], 4));
+                    assert.doesNotThrow(callFn(proclaim.include, [ 1, 2, 3, 4 ], 4));
                 });
 
             });
@@ -807,11 +807,11 @@
             describe('given a string', function () {
 
                 it('should throw if "needle" is not found', function () {
-                    assert.throws(callFn(proclaim.includes, 'hello', 'world'), proclaim.AssertionError);
+                    assert.throws(callFn(proclaim.include, 'hello', 'world'), proclaim.AssertionError);
                 });
 
                 it('should not throw if "needle" is found', function () {
-                    assert.doesNotThrow(callFn(proclaim.includes, 'hello world', 'world'));
+                    assert.doesNotThrow(callFn(proclaim.include, 'hello world', 'world'));
                 });
 
             });
@@ -819,11 +819,11 @@
             describe('given an object', function () {
 
                 it('should throw if the "needle" property is not found', function () {
-                    assert.throws(callFn(proclaim.includes, { hello: true }, 'world'), proclaim.AssertionError);
+                    assert.throws(callFn(proclaim.include, { hello: true }, 'world'), proclaim.AssertionError);
                 });
 
                 it('should not throw if the "needle" property is found', function () {
-                    assert.doesNotThrow(callFn(proclaim.includes, { hello: true, world: false }, 'world'));
+                    assert.doesNotThrow(callFn(proclaim.include, { hello: true, world: false }, 'world'));
                 });
 
             });


### PR DESCRIPTION
Not sure if this was intentional, but the chai method is called `include` rather than `includes`.

It caused an issue when porting the Shunter test-runner to proclaim, but also I can update the tests themselves if this method name is the one you want to keep.