### PR TITLE
set the message of the AssertionError

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -295,7 +295,9 @@
         this.actual = opts.actual;
         this.expected = opts.expected;
         this.operator = opts.operator || '';
-        this.message = opts.message;
+        this.message = opts.message || (this.actual + ' ' +
+                this.operator + ' ' +
+                this.expected);
 
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, opts.stackStartFunction || fail);
@@ -307,14 +309,7 @@
 
     // Assertion error to string
     AssertionError.prototype.toString = function () {
-        if (this.message) {
-            return this.name + ': ' +this.message;
-        } else {
-            return this.name + ': ' +
-                this.actual + ' ' +
-                this.operator + ' ' +
-                this.expected;
-        }
+        return this.name + ': ' +this.message;
     };
 
     // Fail a test


### PR DESCRIPTION
With mocha, the toString() method in the AssertionError doesn't seems to be used