### PR TITLE
better test for node environment before calling require.

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -508,7 +508,7 @@
 
     // Get a formatted assertion error message
     function getAssertionErrorMessage (error) {
-        if (typeof require === 'function') {
+        if (typeof require === 'function' && typeof module !== 'undefined' && module.exports) {
             var util = require('util');
             return [
                 truncateString(util.inspect(error.actual, {depth: null}), 128),


### PR DESCRIPTION
I'm running unit tests in the browser that use require.js to load amd modules. When a test fails without an assertion message I get this error 
`Error: Uncaught Error: Module name "util" has not been loaded yet for context: _. Use require([])
http://requirejs.org/docs/errors.html#notloaded`. Requirejs exposes a require function so there needs to be a better check for node's require.