### PR TITLE
Use util-inspect over util for IE <= 8 compatibility

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -509,11 +509,11 @@
     // Get a formatted assertion error message
     function getAssertionErrorMessage (error) {
         if (typeof require === 'function') {
-            var util = require('util');
+            var inspect = require('util-inspect');
             return [
-                truncateString(util.inspect(error.actual, {depth: null}), 128),
+                truncateString(inspect(error.actual, {depth: null}), 128),
                 error.operator,
-                truncateString(util.inspect(error.expected, {depth: null}), 128)
+                truncateString(inspect(error.expected, {depth: null}), 128)
             ].join(' ');
         }
         else {

--- a/package.json
+++ b/package.json
@@ -1,30 +1,32 @@
 {
-    "name": "proclaim",
-    "version": "3.4.1",
-
-    "description": "A simple assertion library for server and client side JavaScript",
-    "keywords": [ "assert", "test" ],
-    "author": "Rowan Manning (http://rowanmanning.co.uk/)",
-
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/rowanmanning/proclaim.git"
-    },
-    "homepage": "https://github.com/rowanmanning/proclaim",
-    "bugs": "https://github.com/rowanmanning/proclaim/issues",
-
-    "engines": {
-        "node": ">=0.10"
-    },
-    "devDependencies": {
-        "istanbul": "~0.3",
-        "jscs": "^2",
-        "jshint": "^2",
-        "mocha": "^2"
-    },
-
-    "main": "./lib/proclaim.js",
-    "scripts": {
-        "test": "make ci"
-    }
+  "name": "proclaim",
+  "version": "3.4.1",
+  "description": "A simple assertion library for server and client side JavaScript",
+  "keywords": [
+    "assert",
+    "test"
+  ],
+  "author": "Rowan Manning (http://rowanmanning.co.uk/)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rowanmanning/proclaim.git"
+  },
+  "homepage": "https://github.com/rowanmanning/proclaim",
+  "bugs": "https://github.com/rowanmanning/proclaim/issues",
+  "engines": {
+    "node": ">=0.10"
+  },
+  "dependencies": {
+    "util-inspect": "^0.1.8"
+  },
+  "devDependencies": {
+    "istanbul": "~0.3",
+    "jscs": "^2",
+    "jshint": "^2",
+    "mocha": "^2"
+  },
+  "main": "./lib/proclaim.js",
+  "scripts": {
+    "test": "make ci"
+  }
 }


### PR DESCRIPTION
This PR replaces usage of the `util` module with [one that works in pre-ES5 environments](https://github.com/Automattic/util-inspect) to fix some issues in old versions of IE.

The `util` module provided by Browserify uses a lot of ES5-only features; if you're building your project using Browserify and targeting pre-ES5 (IE 8/7/6) environments and hit a code path that uses `getAssertionErrorMessage`, you'll get a bunch of `Object doesn't support this property or method` errors originating from the `util` module.
