### PR TITLE
Make proclaim.deepEqual spec-compliant

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -464,7 +464,7 @@
                 actual.ignoreCase === expected.ignoreCase
             );
         }
-        if (typeof actual !== 'object' && typeof expected !== 'object') {
+        if (typeof actual !== 'object' || typeof expected !== 'object') {
             return actual == expected;
         }
         return objectsEqual(actual, expected);

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -235,6 +235,7 @@
                 assert.throws(callFn(proclaim.deepEqual, true, false), proclaim.AssertionError, 'test1');
                 assert.throws(callFn(proclaim.deepEqual, new Date(), new Date(1000)), proclaim.AssertionError, 'test2');
                 assert.throws(callFn(proclaim.deepEqual, {foo: 'bar', bar: ['baz']}, {bar: 'baz', baz: ['qux']}), proclaim.AssertionError, 'test3');
+                assert.throws(callFn(proclaim.deepEqual, false, {}), proclaim.AssertionError, 'test4');
             });
 
             it('should not throw when keys are in a different order', function () {


### PR DESCRIPTION
It wasn't adhering to point 7.3 of the CommonJS unit testing spec http://wiki.commonjs.org/wiki/Unit_Testing/1.0#Assert