### PR TITLE
Make proclaim work in different environments/directives

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -565,5 +565,6 @@
 
     // Invoke the closure, setting `root` to window (in a browser),
     // self (in a web worker), global (in Node/IOjs) or an empty object.
-    // We avoid using `this` as the argument as `this` is undefined when the `'use strict'` directive is declared.
-}('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {}));
+    // We avoid using `this` as the argument as `this` is undefined
+    // when the `'use strict'` directive is declared.
+}(typeof window === 'object' && window || typeof self === 'object' && self || typeof global === 'object' && global || {}));

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -563,4 +563,7 @@
         global.proclaim = proclaim;
     }
 
-}(this));
+// Invoke the closure, setting `root` to window (in a browser),
+// self (in a web worker), global (in Node/IOjs) or an empty object.
+// We avoid using `this` as the argument as `this` is undefined when the `'use strict'` directive is declared.
+}('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});" );

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -563,8 +563,16 @@
         global.proclaim = proclaim;
     }
 
-    // Invoke the closure, setting `root` to window (in a browser),
-    // self (in a web worker), global (in Node/IOjs) or an empty object.
+    
     // We avoid using `this` as the argument as `this` is undefined
     // when the `'use strict'` directive is declared.
-}(typeof window === 'object' && window || typeof self === 'object' && self || typeof global === 'object' && global || {}));
+}(
+    // Invoke the closure, setting `root` to window (in a browser),
+    typeof window === 'object' && window || 
+    // self (in a web worker),
+    typeof self === 'object' && self || 
+    // global (in Node/IOjs)
+    typeof global === 'object' && global || 
+    // or an empty object.
+    {}
+));

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -563,7 +563,7 @@
         global.proclaim = proclaim;
     }
 
-    
+
     // We avoid using `this` as the argument as `this` is undefined
     // when the `'use strict'` directive is declared.
 }(

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -563,7 +563,7 @@
         global.proclaim = proclaim;
     }
 
-// Invoke the closure, setting `root` to window (in a browser),
-// self (in a web worker), global (in Node/IOjs) or an empty object.
-// We avoid using `this` as the argument as `this` is undefined when the `'use strict'` directive is declared.
+    // Invoke the closure, setting `root` to window (in a browser),
+    // self (in a web worker), global (in Node/IOjs) or an empty object.
+    // We avoid using `this` as the argument as `this` is undefined when the `'use strict'` directive is declared.
 }('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {}));

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -566,4 +566,4 @@
 // Invoke the closure, setting `root` to window (in a browser),
 // self (in a web worker), global (in Node/IOjs) or an empty object.
 // We avoid using `this` as the argument as `this` is undefined when the `'use strict'` directive is declared.
-}('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});" );
+}('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {}));

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -568,11 +568,11 @@
     // when the `'use strict'` directive is declared.
 }(
     // Invoke the closure, setting `root` to window (in a browser),
-    typeof window === 'object' && window || 
+    typeof window === 'object' && window ||
     // self (in a web worker),
-    typeof self === 'object' && self || 
+    typeof self === 'object' && self ||
     // global (in Node/IOjs)
-    typeof global === 'object' && global || 
+    typeof global === 'object' && global ||
     // or an empty object.
     {}
 ));


### PR DESCRIPTION
Without this change, running proclaim using `'use strict'` will cause the `root` argument to be undefined. This will make [assignment on line 561](https://github.com/rowanmanning/proclaim/blob/master/lib/proclaim.js#L561) throw an error as `root.proclaim` is looking for `proclaim` on something that is `undefined`.

This code was taken from the [polyfill-service](https://github.com/Financial-Times/polyfill-service/blob/77af016294ea6a1bb00b9fd2631867fd0c638891/lib/index.js#L241)