### PR TITLE
Use Object.prototype.hasOwnProperty directly

### DIFF
--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -392,7 +392,7 @@
 		// Object#hasOwnProperty
 		if (typeof haystack === 'object' && haystack !== null) {
 			/* eslint-disable no-prototype-builtins */
-			if (haystack.hasOwnProperty(needle)) {
+			if (Object.prototype.hasOwnProperty.call(haystack, needle)) {
 				return true;
 			}
 			/* eslint-enable no-prototype-builtins */

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -910,6 +910,18 @@
 
 			});
 
+			if ('create' in Object && typeof Object.create === 'function') {
+				describe('given an object with no prototype', function() {
+
+					it('should not throw if the "needle" property is found', function() {
+						var obj = Object.create(null);
+						obj.hello = true;
+						obj.world = false;
+						assert.doesNotThrow(callFn(proclaim.include, obj, 'world'));
+					});
+				});
+			}
+
 			describe('given an enhanced object (such as Window)', function() {
 				var MockWindow;
 				var mockWindow;

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -899,10 +899,10 @@
 					assert.doesNotThrow(callFn(proclaim.include, {hello: true,
 						world: false}, 'world'));
 				});
-				
-				it('should not use the objects hasOwnProperty method', function () {
+
+				it('should not use the objects hasOwnProperty method', function() {
 					assert.doesNotThrow(callFn(proclaim.include, {
-						hasOwnProperty: function () {
+						hasOwnProperty: function() {
 							throw new Error();
 						}
 					}, 'world'));

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -904,7 +904,8 @@
 					assert.doesNotThrow(callFn(proclaim.include, {
 						hasOwnProperty: function() {
 							throw new Error();
-						}
+						},
+						world: false
 					}, 'world'));
 				});
 

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -899,6 +899,14 @@
 					assert.doesNotThrow(callFn(proclaim.include, {hello: true,
 						world: false}, 'world'));
 				});
+				
+				it('should not use the objects hasOwnProperty method', function () {
+					assert.doesNotThrow(callFn(proclaim.include, {
+						hasOwnProperty: function () {
+							throw new Error();
+						}
+					}, 'world'));
+				});
 
 			});
 


### PR DESCRIPTION
Currently proclaim is using the tested objects hasOwnProperty method, this would not work for objects which don't inherit from Object.prototype or have their own hasOwnProperty method.

Example objects which don't inherit from Object.prototype are `window` in IE8 and objects without a prototype `Object.create(null)`.