### PR TITLE
Add helper method for testing function is named correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,11 @@ Assert that `actual > expected`.
 Assert that `actual >= expected`.
 
 
+### proclaim.hasName( fn, expected, [message] )
+
+Assert that `fn.name === expected`.
+
+
 Why?
 ----
 

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -300,6 +300,15 @@
 		}
 	};
 
+	var functionsHaveNames = (function foo() { }).name === 'foo';
+	proclaim.hasName = function(fn, expected, msg) {
+		if (functionsHaveNames) {
+			proclaim.strictEqual(fn.name, expected, msg);
+		} else {
+			proclaim.equal(Function.prototype.toString.call(fn).match(/function\s*([^\s]*)\s*\(/)[1], expected, msg);
+		}
+	};
+
 
 	// Aliases
 	// -------

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -319,8 +319,8 @@
 		} else {
 			/* istanbul ignore next */
 			proclaim.equal(Function.prototype.toString.call(fn).match(/function\s*([^\s]*)\s*\(/)[1], expected, msg);
-    }
-  };
+		}
+	};
 
 	// Assert that a function has the expected number of arguments
 	proclaim.arity = function(fn, expected, msg) {

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -305,6 +305,7 @@
 		if (functionsHaveNames) {
 			proclaim.strictEqual(fn.name, expected, msg);
 		} else {
+			/* istanbul ignore next */
 			proclaim.equal(Function.prototype.toString.call(fn).match(/function\s*([^\s]*)\s*\(/)[1], expected, msg);
 		}
 	};

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -1114,6 +1114,31 @@
 
 		});
 
+		describe('.hasName()', function() {
+
+			it('should be a function', function() {
+				assert.isFunction(proclaim.hasName);
+			});
+
+			it('should not throw when called with a function that has the same name as the expected value', function() {
+				assert.doesNotThrow(callFn(proclaim.hasName, function foo(){}, 'foo'));
+			});
+
+			it('should throw when called with a value that is not a function', function() {
+				assert.throws(callFn(proclaim.hasName, 1, 'foo'));
+				assert.throws(callFn(proclaim.hasName, {}, 'foo'));
+				assert.throws(callFn(proclaim.hasName, false, 'foo'));
+				assert.throws(callFn(proclaim.hasName, [], 'foo'));
+				assert.throws(callFn(proclaim.hasName, /./, 'foo'));
+			});
+			
+			it('should throw when called with a value that is a function that has a different name than the expected value', function() {
+				assert.throws(callFn(proclaim.hasName, function(){}, 'foo'));
+				assert.throws(callFn(proclaim.hasName, function bar(){}, 'foo'));
+			});
+
+		});
+
 	});
 
 }());

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -1121,7 +1121,7 @@
 			});
 
 			it('should not throw when called with a function that has the same name as the expected value', function() {
-				assert.doesNotThrow(callFn(proclaim.hasName, function foo(){}, 'foo'));
+				assert.doesNotThrow(callFn(proclaim.hasName, function foo() {}, 'foo'));
 			});
 
 			it('should throw when called with a value that is not a function', function() {
@@ -1131,10 +1131,10 @@
 				assert.throws(callFn(proclaim.hasName, [], 'foo'));
 				assert.throws(callFn(proclaim.hasName, /./, 'foo'));
 			});
-			
+
 			it('should throw when called with a value that is a function that has a different name than the expected value', function() {
-				assert.throws(callFn(proclaim.hasName, function(){}, 'foo'));
-				assert.throws(callFn(proclaim.hasName, function bar(){}, 'foo'));
+				assert.throws(callFn(proclaim.hasName, function() {}, 'foo'));
+				assert.throws(callFn(proclaim.hasName, function bar() {}, 'foo'));
 			});
 
 		});


### PR DESCRIPTION
This helper method has helped find bugs in polyfills whose names get rewritten when they are minified :|

