### PR TITLE
Add proclaim.almostEqual for testing that two numbers are almost equal to one another

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,11 @@ Assert that `actual > expected`.
 Assert that `actual >= expected`.
 
 
+### proclaim.greaterThanOrEqual( actual, expected, [precision = 7], [message] )
+
+Assert that `Math.abs(actual - expected) < (0.5 * Math.pow(10, -precision))`.
+
+
 Why?
 ----
 

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -307,9 +307,9 @@
 		}
 		var tolerance = 0.5 * Math.pow(10, -precision);
 		proclaim.lessThan(Math.abs(actual - expected), tolerance, msg);
-  };
+	};
 
-  // Assert that a property on an object is not enumerable
+	// Assert that a property on an object is not enumerable
 	proclaim.isNotEnumerable = function(obj, property, msg) {
 		if (arePropertyDescriptorsSupported()) {
 			if (hasWorkingGetOwnPropertyDescriptor()) {

--- a/lib/proclaim.js
+++ b/lib/proclaim.js
@@ -300,6 +300,15 @@
 		}
 	};
 
+	// Assert that a value is almost equal to another value
+	proclaim.almostEqual = function(actual, expected, precision, msg) {
+		if (precision === null || precision === undefined) {
+			precision = 7;
+		}
+		var tolerance = 0.5 * Math.pow(10, -precision);
+		proclaim.lessThan(Math.abs(actual - expected), tolerance, msg);
+	};
+
 
 	// Aliases
 	// -------

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -1114,6 +1114,25 @@
 
 		});
 
+		describe('.almostEqual()', function() {
+
+			it('should be a function', function() {
+				assert.isFunction(proclaim.almostEqual);
+			});
+
+			it('should not throw when called with a value that is almost equal to the expected value', function() {
+				assert.doesNotThrow(callFn(proclaim.almostEqual, 1, 1.00000000000001));
+				assert.doesNotThrow(callFn(proclaim.almostEqual, 1, 1.00001, 4));
+				assert.doesNotThrow(callFn(proclaim.almostEqual, 1, 1.1, 0));
+				assert.doesNotThrow(callFn(proclaim.almostEqual, 1, 1));
+			});
+
+			it('should throw when called with a value that is not almost equal to the expected value', function() {
+				assert.throws(callFn(proclaim.almostEqual, 1, 2));
+			});
+
+		});
+
 	});
 
 }());

--- a/test/unit/lib/proclaim.js
+++ b/test/unit/lib/proclaim.js
@@ -1130,9 +1130,9 @@
 
 			it('should throw when called with a value that is not almost equal to the expected value', function() {
 				assert.throws(callFn(proclaim.almostEqual, 1, 2));
-      });
+			});
 
-    });
+		});
 
 		describe('.isEnumerable()', function() {
 


### PR DESCRIPTION
This method is good for testing math functions which have approximate values or have floating point values.

Real-world examples that I have in polyfill.io:
```js
proclaim.almostEqual(Math.tanh(-1), -0.7615941559557649, 13)
proclaim.almostEqual(Math.hypot(3e100, 4e100), 5e100);
proclaim.almostEqual(Math.hypot(3e-300, 4e-300), 5e-300);
proclaim.almostEqual(Math.hypot(6e300, 6e300, 17e300), 19e300);
proclaim.almostEqual(Math.expm1(10), 22025.4657948067165168, -10);
proclaim.almostEqual(Math.cosh(-90), 6.102016471589204e38, -38);
```